### PR TITLE
fix The {external_program_link} issue

### DIFF
--- a/src/pages/programDetail/programDetailView.js
+++ b/src/pages/programDetail/programDetailView.js
@@ -107,7 +107,7 @@ const ProgramView = ({
               {programData.program_link ? (
                 <>
                   <a href={programData.program_link} target="_blank" rel="noopener noreferrer" className={classes.textDecorationNone}>
-                    TARGET
+                    {programData.program_acronym}
                     <img
                       src={externalLinkIcon.src}
                       alt={externalLinkIcon.alt}


### PR DESCRIPTION
Fix the issue The {external_program_link} is always appearing as "TARGET", regardless of which program page is displayed. 