### PR TITLE
INS-1425 - Adapting CCDI Hub header to INS

### DIFF
--- a/src/components/Header/HeaderDesktop.tsx
+++ b/src/components/Header/HeaderDesktop.tsx
@@ -37,7 +37,7 @@ const Header = () => {
       <HeaderContainer>
         <Logo />
         <div className="headerLowerContainer">
-          {path !== '/sitesearch' && <div className="searchBarArea"><SearchBar /></div>}
+          {!path.includes('/globalsearch') && <div className="searchBarArea"><SearchBar /></div>}
         </div>
       </HeaderContainer>
       <div className="navbarContainer"><NavBar /></div>

--- a/src/components/Header/HeaderMobile.tsx
+++ b/src/components/Header/HeaderMobile.tsx
@@ -188,7 +188,7 @@ const Header = () => {
             >
               Menu
             </div>
-            {path !== "/sitesearch" && <div className="searchBarArea"><SearchBar /></div>}
+            {!path.includes("/globalsearch") && <div className="searchBarArea"><SearchBar /></div>}
           </div>
         </HeaderContainer>
       </HeaderBanner>

--- a/src/components/Header/HeaderTablet.tsx
+++ b/src/components/Header/HeaderTablet.tsx
@@ -188,7 +188,7 @@ const Header = () => {
             >
               Menu
             </div>
-            {path !== "/sitesearch" && <div className="searchBarArea"><SearchBar /></div>}
+            {!path.includes("/globalsearch") && <div className="searchBarArea"><SearchBar /></div>}
           </div>
         </HeaderContainer>
       </HeaderBanner>

--- a/src/components/Header/components/SearchBarDesktop.tsx
+++ b/src/components/Header/components/SearchBarDesktop.tsx
@@ -84,13 +84,13 @@ const SearchBar = () => {
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      history.push(`/sitesearch/${localText.trim()}`);
+      history.push(`/globalsearch/${localText.trim()}`);
       setLocalText('');
     }
   };
 
   const handleSearch = () => {
-    history.push(`/sitesearch/${localText.trim()}`);
+    history.push(`/globalsearch/${localText.trim()}`);
     setLocalText('');
   };
 

--- a/src/components/Header/components/SearchBarMobile.tsx
+++ b/src/components/Header/components/SearchBarMobile.tsx
@@ -99,13 +99,13 @@ const SearchBar = () => {
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      history.push(`/sitesearch/${localText.trim()}`);
+      history.push(`/globalsearch/${localText.trim()}`);
       setLocalText('');
     }
   };
 
   const handleSearch = () => {
-    history.push(`/sitesearch/${localText.trim()}`);
+    history.push(`/globalsearch/${localText.trim()}`);
     setLocalText('');
   };
 

--- a/src/components/Header/components/SearchBarTablet.tsx
+++ b/src/components/Header/components/SearchBarTablet.tsx
@@ -88,13 +88,13 @@ const SearchBar = () => {
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      history.push(`/sitesearch/${localText.trim()}`);
+      history.push(`/globalsearch/${localText.trim()}`);
       setLocalText('');
     }
   };
 
   const handleSearch = () => {
-    history.push(`/sitesearch/${localText.trim()}`);
+    history.push(`/globalsearch/${localText.trim()}`);
     setLocalText('');
   };
 

--- a/src/config/globalHeaderData.tsx
+++ b/src/config/globalHeaderData.tsx
@@ -18,19 +18,19 @@ export const headerData = {
 export const navMobileList = [
   {
     name: 'Home',
-    link: 'home',
+    link: '/home',
     id: 'navbar-link-home',
     className: 'navMobileItem',
   },
   {
     name: 'Programs',
-    link: 'programs',
+    link: '/programs',
     id: 'navbar-link-programs',
     className: 'navMobileItem',
   },
   {
     name: 'Datasets',
-    link: 'datasets',
+    link: '/datasets',
     id: 'navbar-link-datasets',
     className: 'navMobileItem',
   },
@@ -55,7 +55,7 @@ export const navbarSublists = {
   About: [
     {
       name: 'About INS',
-      link: 'about',
+      link: '/about',
       id: 'navbar-dropdown-item-about-ins',
       className: 'navMobileSubTitle',
     },


### PR DESCRIPTION
# Primary Issue and Fix: 
[INS-1425](https://tracker.nci.nih.gov/browse/INS-1425)
```
The current implementation matches cancer.gov style but the search bar behavior does not match our intended behavior. 
Please rework this so that the old search bar behavior is unaffected. 
```

This was due to bringing over the new header and search components from another project which redirected to `/sitesearch` which is not relevant to our project. So it has been updated to use our proper subpage of `/globalsearch`

# Secondary Issues and Fixes:
## Second search bar not disappearing
During fixing of this bug it was realized that the top search bar in the header will appeared when on the search results page. This led to having multiple search bars at once (at the top and the large one on the page itself)

This has been fixed by updating `path !== "/globalsearch"` to `!path.includes("/globalsearch")`. The original implementation meant that the path had to exactly `/globalsearch` to disable the searchbar, but the path also includes the search result such as `/globalsearch/query`. By doing this fix, it will disable the top search bar whenever we are on the search results page

## Navigation from the search results page
It was also discovered that when on the search results page, navigating via the navbar did not work. Clicking home would bring the user to `/globalsearch/home` as opposed to `/home`. This was due to the updated navbar using relative paths as opposed to absolute paths. It has been updated to use absolute paths.