### PR TITLE
INS-1468 Breadcrumb text change projects -> programs

### DIFF
--- a/src/pages/projectDetail/projectDetailView.js
+++ b/src/pages/projectDetail/projectDetailView.js
@@ -41,7 +41,7 @@ const ProjectView = ({
         <div className={classes.innerContainer}>
           <div className={classes.breadCrumbs}>
             <Link href="#programs" className={classes.navLink}>
-              Explore Projects
+              Explore Programs
             </Link>
             {'    '}
             <span className={classes.carrot}>


### PR DESCRIPTION
For consistency sake since the breadcrumb link on the project details page links to the programs page on the programs tab we have updated the breadcrumb from 'Explore Projects' to 'Explore Programs'

[INS-1468](https://tracker.nci.nih.gov/browse/INS-1468)