### PR TITLE
INS-1501 convert sample count in search page to be dynamic

### DIFF
--- a/src/pages/dataSets/SearchResult/SearchResult.js
+++ b/src/pages/dataSets/SearchResult/SearchResult.js
@@ -611,14 +611,16 @@ const SearchResult = ({
                   </div>
                 }
                 {
-                  <div className="row align-items-start bodyRow">
-                    <div className="col labelDiv">
-                      <span>Sample Count:&nbsp;&nbsp;&nbsp;</span>
-                      <span className="textSpan sampleCountHighlight">
-                        {rst.content.sample_count}
-                      </span>
+                  rst.content.sample_count != null && rst.content.sample_count !== '' && (
+                    <div className="row align-items-start bodyRow">
+                      <div className="col labelDiv">
+                        <span>Sample Count:&nbsp;&nbsp;&nbsp;</span>
+                        <span className="textSpan sampleCountHighlight">
+                          {rst.content.sample_count}
+                        </span>
+                      </div>
                     </div>
-                  </div>
+                  )
                 }
                 {
                   description !== '' && (


### PR DESCRIPTION
[INS-1501](https://tracker.nci.nih.gov/browse/INS-1501)
- Added conditional rendering to see if the value exists, by checking if it is not null we also allow for 0 to be valid. 
- The empty string check is technically unnecessary since the backend API returns an integer but it matches the implementation of the fields found in the dataset detail page and will be robust in event of API change.