### PR TITLE
INS-1529 made overlapping div not clickable to access menu

### DIFF
--- a/src/pages/landing/landingView.js
+++ b/src/pages/landing/landingView.js
@@ -928,6 +928,7 @@ const styles = () => ({
     },
     '@media (max-width: 480px)': {
       width: '100%',
+      pointerEvents: 'none',
     },
   },
   hoverInteraction: {
@@ -946,7 +947,9 @@ const styles = () => ({
   heroTextWrapper: {
     width: '420px',
     '@media (max-width: 480px)': {
-      padding: '380px 24px 0 24px',
+      margin: '380px 0 0 0',
+      padding: '0 24px',
+      pointerEvents: 'auto',
     },
   },
   buttonText: {


### PR DESCRIPTION
### Overview

The nav button on small screens had issue being clickable. This ended up due to an absolute positioned div on top blocking the clicks due to overlap.

### Change Details (Specifics)

The fix has been made by switching the empty space from padding to margin. And then making the parent div not have pointer-events, allowing us to click through the empty space. (this parent div is positioned absolutely causing this issue - I am not changing the existing styling since that is out of scope).

### Related Ticket(s)

[INS-1529](https://tracker.nci.nih.gov/browse/INS-1529)
