### PR TITLE
INS-1531 Desktop/mobile view do not properly convey alt text

### DIFF
--- a/src/bento/landingPageData.js
+++ b/src/bento/landingPageData.js
@@ -129,7 +129,7 @@ export const landingPageData = {
     callToActionText: 'Contact INS',
   },
   tile4: {
-    alt: 'Cancer patient with abstract data displayed in front of her',
+    alt: 'Cancer patient with abstract data displayed in front of her.',
     img: exploreImg,
     titleText: 'INS DATA GATHERING',
     descriptionText: 'The INS data gathering pipeline uses both expert curation and automated processes to connect programs and studies to research outputs.',

--- a/src/pages/landing/landingView.js
+++ b/src/pages/landing/landingView.js
@@ -401,7 +401,7 @@ const LandingView = ({ classes, statsData }) => {
                   </div>
                 </div>
                 <div className={classes.contentRightBottom}>
-                  <div className={classes.cases} id="tile4_image">
+                  <div className={classes.cases} id="tile4_image" role="img" aria-label={landingPageData.tile4.alt}>
                     <div className={classes.mountainMeadowContentHeader} id="tile4_title">
                       {landingPageData.tile4.titleText}
                     </div>
@@ -464,7 +464,7 @@ const LandingView = ({ classes, statsData }) => {
                   <img
                     className={classes.mobileImg}
                     src={mobileDataTile}
-                    alt="Mobile Data Tile"
+                    alt={landingPageData.tile4.alt}
                     id="Mobile-Data-Tile"
                   />
                 </div>


### PR DESCRIPTION
### Overview

This PR fixes concerns presented by UX team, mainly the missing alt-text on the home page card.

### Change Details (Specifics)

- Update the alt text to include the period
- Fix the homepage MOBILE view not using the alt text specified
- Fix the desktop view not specifying any alternative text at all (not a 508 issue)

### Related Ticket(s)

INS-1531
