### PR TITLE
fix: Trivy scan should be enabled by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         description: fail the build if vulnerabilities are found
         required: true 
-        default: false
+        default: true
 jobs:
   build:
     name: Build Image


### PR DESCRIPTION
### Overview

This updates the GitHub build action to enforce Trivy by default

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
