### PR TITLE
INS-1564 Export button disabling on download

### DIFF
--- a/src/api/exportApi.js
+++ b/src/api/exportApi.js
@@ -2,34 +2,32 @@ import env from '../utils/env';
 
 const baseUrl = env.REACT_APP_REST_BACKEND_API;
 
-export function getSearchResult(body) {
-  fetch(`${baseUrl}export`, {
+export async function getSearchResult(body) {
+  const response = await fetch(`${baseUrl}export`, {
     method: 'POST',
     body: JSON.stringify(body),
     headers: { 'Content-Type': 'application/json' },
-  }).then((response) => {
-    response.blob().then((blob) => {
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-
-      // Get the current date and timestamp
-      const now = new Date();
-      const year = now.getFullYear();
-      const month = String(now.getMonth() + 1).padStart(2, '0'); // Add leading zero if needed
-      const day = String(now.getDate()).padStart(2, '0'); // Add leading zero if needed
-      const date = `${year}-${month}-${day}`;
-
-      const hours = String(now.getHours()).padStart(2, '0');
-      const minutes = String(now.getMinutes()).padStart(2, '0');
-      const seconds = String(now.getSeconds()).padStart(2, '0');
-      const timestamp = `${hours}-${minutes}-${seconds}`;
-
-      // Set the filename dynamically
-      a.download = `INS datasets download ${date} ${timestamp}.csv`;
-      a.click();
-    });
   });
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+
+  // Get the current date and timestamp
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0'); // Add leading zero if needed
+  const day = String(now.getDate()).padStart(2, '0'); // Add leading zero if needed
+  const date = `${year}-${month}-${day}`;
+
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const seconds = String(now.getSeconds()).padStart(2, '0');
+  const timestamp = `${hours}-${minutes}-${seconds}`;
+
+  // Set the filename dynamically
+  a.download = `INS datasets download ${date} ${timestamp}.csv`;
+  a.click();
 }
 
 export default getSearchResult;

--- a/src/pages/dataSets/ExportButton/ExportButton.css
+++ b/src/pages/dataSets/ExportButton/ExportButton.css
@@ -28,9 +28,14 @@
   top: 5px;
 }
 
-.buttonStyle:hover {
+.buttonStyle:hover:not(:disabled) {
   color: lightgray;
   text-decoration: none;
+}
+
+.buttonStyle:disabled {
+  background: #7a9ba3;
+  cursor: not-allowed;
 }
 
 .buttonStyle::after {

--- a/src/pages/dataSets/ExportButton/ExportButton.js
+++ b/src/pages/dataSets/ExportButton/ExportButton.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import * as exportApi from '../../../api/exportApi';
 import './ExportButton.css';
@@ -7,14 +7,23 @@ import ExportIconImg from './export.svg';
 const ExportButton = ({
   searchCriteria,
 }) => {
-  const handleExport = (event) => {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async (event) => {
     event.preventDefault();
-    exportApi.getSearchResult(searchCriteria);
+    if (isExporting) return;
+
+    setIsExporting(true);
+    try {
+      await exportApi.getSearchResult(searchCriteria);
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   return (
     <>
-      <button type="button" className="buttonStyle" onClick={handleExport}>
+      <button type="button" className="buttonStyle" onClick={handleExport} disabled={isExporting}>
         <span className="spanText">
           <img src={ExportIconImg} alt="export-icon" />
           Export

--- a/src/pages/dataSets/ExportButton/ExportButton.js
+++ b/src/pages/dataSets/ExportButton/ExportButton.js
@@ -16,6 +16,8 @@ const ExportButton = ({
     setIsExporting(true);
     try {
       await exportApi.getSearchResult(searchCriteria);
+    } catch (error) {
+      console.error('Failed to export datasets:', error);
     } finally {
       setIsExporting(false);
     }

--- a/src/pages/dataSets/ExportButton/ExportButton.test.js
+++ b/src/pages/dataSets/ExportButton/ExportButton.test.js
@@ -1,0 +1,204 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+} from '@testing-library/react';
+import ExportButton from './ExportButton';
+import * as exportApi from '../../../api/exportApi';
+
+// Mock the export API
+jest.mock('../../../api/exportApi', () => ({
+  getSearchResult: jest.fn(),
+}));
+
+// Mock the CSS import
+jest.mock('./ExportButton.css', () => ({}));
+
+// Mock the SVG import
+jest.mock('./export.svg', () => 'export-icon.svg');
+
+const defaultSearchCriteria = {
+  search_text: '',
+  filters: {
+    primary_disease: [],
+    dataset_source_repo: [],
+  },
+  pageInfo: {
+    page: 1,
+    pageSize: 10,
+  },
+  sort: {
+    name: 'Dataset',
+    k: 'dataset_title_sort',
+    v: 'asc',
+  },
+};
+
+// Helper to flush promises
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('ExportButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render the export button', () => {
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByText('Export')).toBeInTheDocument();
+    });
+
+    it('should render the export icon', () => {
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const icon = screen.getByAltText('export-icon');
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('src', 'export-icon.svg');
+    });
+
+    it('should have the correct button class', () => {
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('buttonStyle');
+    });
+
+    it('should not be disabled by default', () => {
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  describe('Export Functionality', () => {
+    it('should call exportApi.getSearchResult when clicked', () => {
+      exportApi.getSearchResult.mockResolvedValueOnce();
+
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      expect(exportApi.getSearchResult).toHaveBeenCalledWith(defaultSearchCriteria);
+    });
+
+    it('should pass searchCriteria with filters to the API', () => {
+      const searchCriteriaWithFilters = {
+        ...defaultSearchCriteria,
+        search_text: 'cancer',
+        filters: {
+          primary_disease: ['Breast Cancer'],
+          dataset_source_repo: ['dbGaP'],
+        },
+      };
+
+      exportApi.getSearchResult.mockResolvedValueOnce();
+
+      render(<ExportButton searchCriteria={searchCriteriaWithFilters} />);
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      expect(exportApi.getSearchResult).toHaveBeenCalledWith(searchCriteriaWithFilters);
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should disable the button while export is in progress', () => {
+      exportApi.getSearchResult.mockImplementationOnce(
+        () => new Promise(() => {}),
+      );
+
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      // Button should be disabled while waiting
+      expect(button).toBeDisabled();
+    });
+
+    it('should prevent multiple clicks while export is in progress', () => {
+      exportApi.getSearchResult.mockImplementationOnce(
+        () => new Promise(() => {}),
+      );
+
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+
+      // First click
+      fireEvent.click(button);
+      expect(exportApi.getSearchResult).toHaveBeenCalledTimes(1);
+
+      // Second click while disabled
+      fireEvent.click(button);
+      expect(exportApi.getSearchResult).toHaveBeenCalledTimes(1);
+
+      // Third click while disabled
+      fireEvent.click(button);
+      expect(exportApi.getSearchResult).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-enable button after export completes successfully', async () => {
+      exportApi.getSearchResult.mockResolvedValueOnce();
+
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+
+      await act(async () => {
+        fireEvent.click(button);
+        await flushPromises();
+      });
+
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should re-enable button even if export fails', async () => {
+      exportApi.getSearchResult.mockImplementationOnce(
+        () => Promise.reject(new Error('Export failed')),
+      );
+
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+
+      await act(async () => {
+        fireEvent.click(button);
+        // Allow promise rejection to be handled
+        await flushPromises();
+      });
+
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should allow clicking again after previous export completes', async () => {
+      exportApi.getSearchResult.mockResolvedValue();
+
+      render(<ExportButton searchCriteria={defaultSearchCriteria} />);
+
+      const button = screen.getByRole('button');
+
+      // First export
+      await act(async () => {
+        fireEvent.click(button);
+        await flushPromises();
+      });
+
+      expect(button).not.toBeDisabled();
+
+      // Second export should work
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      expect(exportApi.getSearchResult).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
### Overview

- The export button on the datasets search page had no user feedback when downloading. This update includes changes that will introduce a disabled state (greyed out, unclickable). 
- Since we are now tracking the state of the button the download function had to be converted into a async/await for the promise. 
- The PR also includes a test suite for the component.

### Change Details (Specifics)

- Add loading state to the Export button on the Datasets page to prevent multiple simultaneous export requests
- Button is disabled during export with visual feedback (grayed-out background, cursor: not-allowed)
- Hover effect is disabled while button is in disabled state
- Convert export API to async/await for proper Promise handling
- Add error logging following the repo's standard pattern (console.error)
- Add comprehensive test coverage (11 tests) for the ExportButton component


### Related Ticket(s)
[INS-1564](https://tracker.nci.nih.gov/browse/INS-1564)
