### PR TITLE
INS-1560 Add in dataset storage field + update other match in naming format

### DIFF
--- a/src/bento/datasetDetailData.js
+++ b/src/bento/datasetDetailData.js
@@ -103,7 +103,7 @@ const basicInformationFields = [
     datafield: 'dataset_storage_distribution',
     dynamic: true,
     isLink: false,
-    formatSemicolon: false,
+    formatSemicolon: true,
     tooltip: 'Systems designed to securely house, manage, and disseminate large datasets, such as genomic sequencing or medical imaging.',
   },
 ];

--- a/src/bento/datasetDetailData.js
+++ b/src/bento/datasetDetailData.js
@@ -98,6 +98,14 @@ const basicInformationFields = [
     formatSemicolon: true,
     tooltip: 'Each of NCI\'s divisions, offices, and centers (DOC) who work together to build and maintain comprehensive cancer research',
   },
+  {
+    label: 'Data Storage and Distribution Platform',
+    datafield: 'dataset_storage_distribution',
+    dynamic: true,
+    isLink: false,
+    formatSemicolon: false,
+    tooltip: 'Systems designed to securely house, manage, and disseminate large datasets, such as genomic sequencing or medical imaging.',
+  },
 ];
 
 // Pre-computed flag: true if all basicInformationFields have dynamic: true
@@ -237,6 +245,7 @@ query datasetDetails($dataset_source_id: String) {
         dataset_source_id
         dataset_source_repo
         dataset_source_url
+        dataset_storage_distribution
         dataset_title
         dataset_year_enrollment_ended
         dataset_year_enrollment_started

--- a/src/pages/dataSetDetail/dataSetDetailView.test.js
+++ b/src/pages/dataSetDetail/dataSetDetailView.test.js
@@ -86,6 +86,7 @@ const createMockData = (overrides = {}) => ({
   limitations_for_reuse: 'None',
   study_links: 'https://example.com/study',
   related_terms: 'genomics; oncology',
+  dataset_storage_distribution: 'Test Storage Platform',
   ...overrides,
 });
 
@@ -110,6 +111,7 @@ describe('DataSetDetailView', () => {
         institute: null,
         funding_source: null,
         dataset_doc: null,
+        dataset_storage_distribution: null,
       });
 
       render(<DataSetDetailView data={data} files={[]} />);
@@ -566,6 +568,362 @@ describe('DataSetDetailView', () => {
       expect(screen.getByText('BRCA1; BRCA2; TP53')).toBeInTheDocument();
     });
   });
+});
+
+// ============================================================================
+// COMPREHENSIVE DATA-DRIVEN FIELD TESTS
+// These tests ensure all fields in basicInformationFields and dataDetailsFields
+// are properly tested for dynamic visibility behavior
+// ============================================================================
+
+// Basic Information Fields - all are dynamic (hide when null/empty)
+const basicInformationDynamicFields = [
+  {
+    datafield: 'PI_name',
+    label: 'Investigator(s)',
+    testId: 'basic-info-PI_name',
+    validValue: 'Dr. Smith',
+  },
+  {
+    datafield: 'dataset_source_url',
+    label: 'Study Page',
+    testId: 'basic-info-dataset_source_url',
+    validValue: 'https://example.com',
+  },
+  {
+    datafield: 'dataset_pmid',
+    label: 'Cited Publication PMID(s)',
+    testId: 'basic-info-dataset_pmid',
+    validValue: '12345',
+  },
+  {
+    datafield: 'release_date',
+    label: 'Release Date',
+    testId: 'basic-info-release_date',
+    validValue: '2024-01-01',
+  },
+  {
+    datafield: 'institute',
+    label: 'Institute',
+    testId: 'basic-info-institute',
+    validValue: 'Test Institute',
+  },
+  {
+    datafield: 'funding_source',
+    label: 'Funding Source(s)',
+    testId: 'basic-info-funding_source',
+    validValue: 'NIH Grant',
+  },
+  {
+    datafield: 'dataset_doc',
+    label: 'NCI Division/Office/Center',
+    testId: 'basic-info-dataset_doc',
+    validValue: 'NCI',
+  },
+  {
+    datafield: 'dataset_storage_distribution',
+    label: 'Data Storage and Distribution Platform',
+    testId: 'basic-info-dataset_storage_distribution',
+    validValue: 'Cloud Storage',
+  },
+];
+
+// Data Details Fields - dynamic fields (excluding paired and non-dynamic)
+const dataDetailsDynamicFields = [
+  {
+    datafield: 'study_type',
+    label: 'Study Type',
+    testId: 'data-detail-study_type',
+    validValue: 'Clinical Trial',
+  },
+  {
+    datafield: 'assay_method',
+    label: 'Assay Method',
+    testId: 'data-detail-assay_method',
+    validValue: 'WGS',
+  },
+  {
+    datafield: 'participant_count',
+    label: 'Participant Count',
+    testId: 'data-detail-participant_count',
+    validValue: 100,
+  },
+  {
+    datafield: 'sample_count',
+    label: 'Sample Count',
+    testId: 'data-detail-sample_count',
+    validValue: 200,
+  },
+  {
+    datafield: 'related_genes',
+    label: 'Related Genes',
+    testId: 'data-detail-related_genes',
+    validValue: 'BRCA1; BRCA2',
+  },
+  {
+    datafield: 'related_diseases',
+    label: 'Related Diseases',
+    testId: 'data-detail-related_diseases',
+    validValue: 'Breast Cancer',
+  },
+  {
+    datafield: 'limitations_for_reuse',
+    label: 'Limitations for Reuse',
+    testId: 'data-detail-limitations_for_reuse',
+    validValue: 'None',
+  },
+  {
+    datafield: 'study_links',
+    label: 'Related Link(s)',
+    testId: 'data-detail-study_links',
+    validValue: 'https://example.com/study',
+  },
+  {
+    datafield: 'related_terms',
+    label: 'Related Terms',
+    testId: 'data-detail-related_terms',
+    validValue: 'genomics; oncology',
+  },
+];
+
+// Non-dynamic fields (always show regardless of value)
+const nonDynamicFields = [
+  {
+    datafield: 'primary_disease',
+    label: 'Primary Disease',
+    testId: 'data-detail-primary_disease',
+  },
+];
+
+// Paired fields (show if at least one value exists)
+const pairedFields = [
+  {
+    datafield: 'dataset_minimum_age_at_baseline',
+    pairedField: 'dataset_maximum_age_at_baseline',
+    label: 'Age at Baseline (Min - Max)',
+    testId: 'data-detail-dataset_minimum_age_at_baseline',
+    validFirstValue: '18',
+    validSecondValue: '65',
+  },
+  {
+    datafield: 'dataset_year_enrollment_started',
+    pairedField: 'dataset_year_enrollment_ended',
+    label: 'Enrollment Year (Start - End)',
+    testId: 'data-detail-dataset_year_enrollment_started',
+    validFirstValue: '2020',
+    validSecondValue: '2023',
+  },
+];
+
+describe('Basic Information Fields - Comprehensive Dynamic Field Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(basicInformationDynamicFields)(
+    'Basic Info Field: $label ($datafield)',
+    ({
+      datafield, label, testId, validValue,
+    }) => {
+      it(`should NOT render ${label} when value is null`, () => {
+        const data = createMockData({ [datafield]: null });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+      });
+
+      it(`should NOT render ${label} when value is empty string`, () => {
+        const data = createMockData({ [datafield]: '' });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+      });
+
+      it(`should render ${label} when value exists`, () => {
+        const data = createMockData({ [datafield]: validValue });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+      });
+
+      it(`should display label "${label}" when field has data`, () => {
+        const data = createMockData({ [datafield]: validValue });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+    },
+  );
+});
+
+describe('Data Details Fields - Comprehensive Dynamic Field Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(dataDetailsDynamicFields)(
+    'Data Details Field: $label ($datafield)',
+    ({
+      datafield, label, testId, validValue,
+    }) => {
+      it(`should NOT render ${label} when value is null`, () => {
+        const data = createMockData({ [datafield]: null });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+      });
+
+      it(`should NOT render ${label} when value is empty string`, () => {
+        const data = createMockData({ [datafield]: '' });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+      });
+
+      it(`should render ${label} when value exists`, () => {
+        const data = createMockData({ [datafield]: validValue });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+      });
+
+      it(`should display label "${label}" when field has data`, () => {
+        const data = createMockData({ [datafield]: validValue });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+    },
+  );
+});
+
+describe('Non-Dynamic Fields - Always Visible Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(nonDynamicFields)(
+    'Non-Dynamic Field: $label ($datafield)',
+    ({ datafield, label, testId }) => {
+      it(`should render ${label} even when value is null`, () => {
+        const data = createMockData({ [datafield]: null });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+      });
+
+      it(`should render ${label} even when value is empty string`, () => {
+        const data = createMockData({ [datafield]: '' });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+      });
+
+      it(`should render ${label} when value exists`, () => {
+        const data = createMockData({ [datafield]: 'Test Value' });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+      });
+
+      it(`should display label "${label}"`, () => {
+        const data = createMockData({ [datafield]: 'Test Value' });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+    },
+  );
+});
+
+describe('Paired Fields - Comprehensive Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(pairedFields)(
+    'Paired Field: $label',
+    ({
+      datafield, pairedField, label, testId, validFirstValue, validSecondValue,
+    }) => {
+      it(`should render ${label} when both values exist`, () => {
+        const data = createMockData({
+          [datafield]: validFirstValue,
+          [pairedField]: validSecondValue,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+        expect(screen.getByText(`${validFirstValue} - ${validSecondValue}`)).toBeInTheDocument();
+      });
+
+      it(`should render ${label} when only first value exists`, () => {
+        const data = createMockData({
+          [datafield]: validFirstValue,
+          [pairedField]: null,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+        const fieldElement = screen.getByTestId(testId);
+        expect(fieldElement.textContent).toContain(`${validFirstValue} -`);
+      });
+
+      it(`should render ${label} when only second value exists`, () => {
+        const data = createMockData({
+          [datafield]: null,
+          [pairedField]: validSecondValue,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+        const fieldElement = screen.getByTestId(testId);
+        expect(fieldElement.textContent).toContain(`- ${validSecondValue}`);
+      });
+
+      it(`should NOT render ${label} when both values are null`, () => {
+        const data = createMockData({
+          [datafield]: null,
+          [pairedField]: null,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+      });
+
+      it(`should NOT render ${label} when both values are empty strings`, () => {
+        const data = createMockData({
+          [datafield]: '',
+          [pairedField]: '',
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+      });
+
+      it(`should render ${label} with zero as first value`, () => {
+        const data = createMockData({
+          [datafield]: 0,
+          [pairedField]: validSecondValue,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        const fieldElement = screen.getByTestId(testId);
+        expect(fieldElement.textContent).toContain(`0 - ${validSecondValue}`);
+      });
+
+      it(`should render ${label} with zero as second value`, () => {
+        const data = createMockData({
+          [datafield]: validFirstValue,
+          [pairedField]: 0,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        const fieldElement = screen.getByTestId(testId);
+        expect(fieldElement.textContent).toContain(`${validFirstValue} - 0`);
+      });
+
+      it(`should render ${label} with both values as zero`, () => {
+        const data = createMockData({
+          [datafield]: 0,
+          [pairedField]: 0,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        const fieldElement = screen.getByTestId(testId);
+        expect(fieldElement.textContent).toContain('0 - 0');
+      });
+
+      it(`should display label "${label}"`, () => {
+        const data = createMockData({
+          [datafield]: validFirstValue,
+          [pairedField]: validSecondValue,
+        });
+        render(<DataSetDetailView data={data} files={[]} />);
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+    },
+  );
 });
 
 // Edge case tests with mocked config

--- a/src/pages/dataSets/SearchResult/SearchResult.js
+++ b/src/pages/dataSets/SearchResult/SearchResult.js
@@ -330,20 +330,21 @@ const SearchResultContainer = styled.div`
 `;
 
 // Configuration for hidden fields that appear as "Other Match in..." when highlighted
+// Display names match the Dataset Details page headers
 const HIDDEN_FIELDS_CONFIG = [
-  { fieldName: 'dataset_source_url', displayName: 'study page' },
-  { fieldName: 'PI_name', displayName: 'PI name' },
-  { fieldName: 'dataset_pmid', displayName: 'dataset pmid' },
-  { fieldName: 'funding_source', displayName: 'funding source' },
-  { fieldName: 'related_diseases', displayName: 'related diseases' },
-  { fieldName: 'related_terms', displayName: 'related terms' },
-  { fieldName: 'study_links', displayName: 'study links' },
-  { fieldName: 'related_genes', displayName: 'related genes' },
-  { fieldName: 'assay_method', displayName: 'assay method' },
-  { fieldName: 'limitations_for_reuse', displayName: 'limitations for reuse' },
+  { fieldName: 'dataset_source_url', displayName: 'Study Page' },
+  { fieldName: 'PI_name', displayName: 'Investigator(s)' },
+  { fieldName: 'dataset_pmid', displayName: 'Cited Publication PMID(s)' },
+  { fieldName: 'funding_source', displayName: 'Funding Source(s)' },
+  { fieldName: 'related_diseases', displayName: 'Related Diseases' },
+  { fieldName: 'related_terms', displayName: 'Related Terms' },
+  { fieldName: 'study_links', displayName: 'Related Link(s)' },
+  { fieldName: 'related_genes', displayName: 'Related Genes' },
+  { fieldName: 'assay_method', displayName: 'Assay Method' },
+  { fieldName: 'limitations_for_reuse', displayName: 'Limitations for Reuse' },
   { fieldName: 'dataset_doc', displayName: 'NCI Division/Office/Center' },
-  { fieldName: 'institute', displayName: 'institute' },
-  { fieldName: 'experimental_approaches', displayName: 'experimental approaches' },
+  { fieldName: 'institute', displayName: 'Institute' },
+  { fieldName: 'experimental_approaches', displayName: 'Experimental Approaches' },
   { fieldName: 'dataset_storage_distribution', displayName: 'Data Storage and Distribution Platform' },
 ];
 

--- a/src/pages/dataSets/SearchResult/SearchResult.js
+++ b/src/pages/dataSets/SearchResult/SearchResult.js
@@ -344,6 +344,7 @@ const HIDDEN_FIELDS_CONFIG = [
   { fieldName: 'dataset_doc', displayName: 'NCI Division/Office/Center' },
   { fieldName: 'institute', displayName: 'institute' },
   { fieldName: 'experimental_approaches', displayName: 'experimental approaches' },
+  { fieldName: 'dataset_storage_distribution', displayName: 'Data Storage and Distribution Platform' },
 ];
 
 const SearchResult = ({

--- a/src/pages/dataSets/SearchResult/SearchResult.test.jsx
+++ b/src/pages/dataSets/SearchResult/SearchResult.test.jsx
@@ -22,6 +22,9 @@ jest.mock('bootstrap', () => ({
 // Mock html-react-parser
 jest.mock('html-react-parser', () => jest.fn((str) => str));
 
+// Helper function to escape special regex characters in a string
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 // Helper function to create a mock result with configurable fields
 // Usage: createMockResult({ sample_count: 100, study_type: 'Clinical Trial' })
 // With highlights: createMockResult({
@@ -677,18 +680,18 @@ describe('Hidden Fields - Additional Matches', () => {
   // Test configuration for hidden fields that appear as "Other Match in..."
   // This should match all fields in the hideContent array in SearchResult.js
   const hiddenFields = [
-    { fieldName: 'dataset_source_url', displayName: 'study page', searchTerm: 'example.com' },
-    { fieldName: 'PI_name', displayName: 'PI name', searchTerm: 'Smith' },
-    { fieldName: 'dataset_pmid', displayName: 'dataset pmid', searchTerm: '12345' },
-    { fieldName: 'funding_source', displayName: 'funding source', searchTerm: 'NIH' },
-    { fieldName: 'related_diseases', displayName: 'related diseases', searchTerm: 'Diabetes' },
-    { fieldName: 'related_terms', displayName: 'related terms', searchTerm: 'genomics' },
-    { fieldName: 'study_links', displayName: 'study links', searchTerm: 'http' },
-    { fieldName: 'related_genes', displayName: 'related genes', searchTerm: 'BRCA1' },
-    { fieldName: 'assay_method', displayName: 'assay method', searchTerm: 'RNA-seq' },
+    { fieldName: 'dataset_source_url', displayName: 'Study Page', searchTerm: 'example.com' },
+    { fieldName: 'PI_name', displayName: 'Investigator(s)', searchTerm: 'Smith' },
+    { fieldName: 'dataset_pmid', displayName: 'Cited Publication PMID(s)', searchTerm: '12345' },
+    { fieldName: 'funding_source', displayName: 'Funding Source(s)', searchTerm: 'NIH' },
+    { fieldName: 'related_diseases', displayName: 'Related Diseases', searchTerm: 'Diabetes' },
+    { fieldName: 'related_terms', displayName: 'Related Terms', searchTerm: 'genomics' },
+    { fieldName: 'study_links', displayName: 'Related Link(s)', searchTerm: 'http' },
+    { fieldName: 'related_genes', displayName: 'Related Genes', searchTerm: 'BRCA1' },
+    { fieldName: 'assay_method', displayName: 'Assay Method', searchTerm: 'RNA-seq' },
     {
       fieldName: 'limitations_for_reuse',
-      displayName: 'limitations for reuse',
+      displayName: 'Limitations for Reuse',
       searchTerm: 'restriction',
     },
     {
@@ -696,10 +699,10 @@ describe('Hidden Fields - Additional Matches', () => {
       displayName: 'NCI Division/Office/Center',
       searchTerm: 'Division',
     },
-    { fieldName: 'institute', displayName: 'institute', searchTerm: 'Institute' },
+    { fieldName: 'institute', displayName: 'Institute', searchTerm: 'Institute' },
     {
       fieldName: 'experimental_approaches',
-      displayName: 'experimental approaches',
+      displayName: 'Experimental Approaches',
       searchTerm: 'approach',
     },
     {
@@ -726,7 +729,7 @@ describe('Hidden Fields - Additional Matches', () => {
 
       renderWithRouter(<SearchResult {...props} />);
 
-      expect(screen.queryByText(new RegExp(`Other Match in ${displayName}`, 'i')))
+      expect(screen.queryByText(new RegExp(`Other Match in ${escapeRegExp(displayName)}`, 'i')))
         .not.toBeInTheDocument();
     });
 
@@ -750,7 +753,7 @@ describe('Hidden Fields - Additional Matches', () => {
 
       renderWithRouter(<SearchResult {...props} />);
 
-      expect(screen.getByText(new RegExp(`Other Match in ${displayName}`, 'i')))
+      expect(screen.getByText(new RegExp(`Other Match in ${escapeRegExp(displayName)}`, 'i')))
         .toBeInTheDocument();
       // Verify the highlighted value is shown
       const matchElement = screen.getByTestId('additional-match');
@@ -773,7 +776,7 @@ describe('Hidden Fields - Additional Matches', () => {
 
       renderWithRouter(<SearchResult {...props} />);
 
-      expect(screen.queryByText(new RegExp(`Other Match in ${displayName}`, 'i')))
+      expect(screen.queryByText(new RegExp(`Other Match in ${escapeRegExp(displayName)}`, 'i')))
         .not.toBeInTheDocument();
     });
 
@@ -793,7 +796,7 @@ describe('Hidden Fields - Additional Matches', () => {
 
       renderWithRouter(<SearchResult {...props} />);
 
-      expect(screen.queryByText(new RegExp(`Other Match in ${displayName}`, 'i')))
+      expect(screen.queryByText(new RegExp(`Other Match in ${escapeRegExp(displayName)}`, 'i')))
         .not.toBeInTheDocument();
     });
   });

--- a/src/pages/dataSets/SearchResult/SearchResult.test.jsx
+++ b/src/pages/dataSets/SearchResult/SearchResult.test.jsx
@@ -385,8 +385,8 @@ describe('Basic Functionality', () => {
       renderWithRouter(<SearchResult {...props} />);
 
       // "Repository" is in dataset_source_repo filter
-      // So it should NOT appear as "Other Match in PI name" even though PI_name contains it
-      expect(screen.queryByText(/Other Match in PI name/i)).not.toBeInTheDocument();
+      // So it should NOT appear as "Other Match in Investigator(s)" even though PI_name contains it
+      expect(screen.queryByText(/Other Match in Investigator\(s\)/i)).not.toBeInTheDocument();
     });
 
     it('should NOT highlight filter values when both primary_disease and dataset_source_repo filters are present', () => {
@@ -823,11 +823,11 @@ describe('Hidden Fields - Additional Matches', () => {
     renderWithRouter(<SearchResult {...props} />);
 
     // Should find matches in both fields that backend highlighted
-    expect(screen.getByText(/Other Match in related genes/i)).toBeInTheDocument();
-    expect(screen.getByText(/Other Match in funding source/i)).toBeInTheDocument();
+    expect(screen.getByText(/Other Match in Related Genes/i)).toBeInTheDocument();
+    expect(screen.getByText(/Other Match in Funding Source\(s\)/i)).toBeInTheDocument();
 
     // Should NOT find match in PI_name (backend didn't highlight it)
-    expect(screen.queryByText(/Other Match in PI name/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Other Match in Investigator\(s\)/i)).not.toBeInTheDocument();
 
     // Verify the highlighted values are correctly displayed
     const additionalMatchElements = screen.getAllByTestId('additional-match');
@@ -863,7 +863,7 @@ describe('Hidden Fields - Additional Matches', () => {
 
     renderWithRouter(<SearchResult {...props} />);
 
-    expect(screen.getByText(/Other Match in funding source/i)).toBeInTheDocument();
+    expect(screen.getByText(/Other Match in Funding Source\(s\)/i)).toBeInTheDocument();
   });
 
   it('should NOT display hidden fields when there is no search text', () => {
@@ -904,7 +904,7 @@ describe('Hidden Fields - Additional Matches', () => {
 
     renderWithRouter(<SearchResult {...props} />);
 
-    expect(screen.getByText(/Other Match in related diseases/i)).toBeInTheDocument();
+    expect(screen.getByText(/Other Match in Related Diseases/i)).toBeInTheDocument();
   });
 
   describe('Highlighting', () => {

--- a/src/pages/dataSets/SearchResult/SearchResult.test.jsx
+++ b/src/pages/dataSets/SearchResult/SearchResult.test.jsx
@@ -56,6 +56,7 @@ const createMockResult = (overrides = {}) => {
       dataset_doc: 'Doc 1',
       institute: 'Test Institute',
       experimental_approaches: 'Test Approach',
+      dataset_storage_distribution: 'Test Storage Platform',
       ...contentOverrides,
     },
     highlight: highlight || {},
@@ -700,6 +701,11 @@ describe('Hidden Fields - Additional Matches', () => {
       fieldName: 'experimental_approaches',
       displayName: 'experimental approaches',
       searchTerm: 'approach',
+    },
+    {
+      fieldName: 'dataset_storage_distribution',
+      displayName: 'Data Storage and Distribution Platform',
+      searchTerm: 'storage',
     },
   ];
 


### PR DESCRIPTION
### Overview
Adding in new field (dataset storage) for the dataset search results page + dataset details page

### Change Details (Specifics)
- Added new field w/ config in the dataset details config
- Updated GraphQL for dataset details
- Add in dataset storage in the hidden field config for the search results page
- Updated dataset details tests to be data driven like the search results tests
- Updated naming convention for the hidden field configs to be capitalized
- Updated search results tests with escapeRegExp to handle new '(s)' naming convention

### Related Ticket(s)
[INS-1560](https://tracker.nci.nih.gov/browse/INS-1560)
