### PR TITLE
Bump nginx image to 1.29.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN NODE_OPTIONS="--openssl-legacy-provider" npm run build --silent
 
 FROM nginx:1.29.6-alpine3.23-slim AS fnl_base_image
 
-RUN apk update && apk upgrade libxml2
+# zlib: CVE-2026-22184
+RUN apk update && apk upgrade libxml2 && apk add --no-cache --upgrade zlib=1.3.2-r0
 
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html
 COPY --from=build /usr/src/app/config/inject.template.js /usr/share/nginx/html/inject.template.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19.6-alpine3.23 as build
+FROM node:20.19.6-alpine3.23 AS build
 
 
 WORKDIR /usr/src/app
@@ -14,7 +14,7 @@ RUN NODE_OPTIONS="--max-old-space-size=4096" npm set progress=false
 RUN NODE_OPTIONS="--max-old-space-size=4096" npm ci --legacy-peer-deps
 RUN NODE_OPTIONS="--openssl-legacy-provider" npm run build --silent
 
-FROM nginx:1.29.4-alpine3.23-slim AS fnl_base_image
+FROM nginx:1.29.6-alpine3.23-slim AS fnl_base_image
 
 RUN apk update && apk upgrade libxml2
 


### PR DESCRIPTION
### Overview

Bump Nginx image to 1.29.6 and manually patch zlib.

### Change Details (Specifics)

N/A

### Related Ticket(s)

INS-1585
