### PR TITLE
fix: Export button incorrectly paginating only 10 items

### DIFF
--- a/src/api/exportApi.js
+++ b/src/api/exportApi.js
@@ -3,9 +3,15 @@ import env from '../utils/env';
 const baseUrl = env.REACT_APP_REST_BACKEND_API;
 
 export async function getSearchResult(body) {
+  // TODO: Chunk the export request pages
+  const { pageInfo, ...searchBody } = body || {};
+  const totalItems = pageInfo.total || 10000;
   const response = await fetch(`${baseUrl}export`, {
     method: 'POST',
-    body: JSON.stringify(body),
+    body: JSON.stringify({
+      ...searchBody,
+      pageInfo: { page: 1, pageSize: totalItems },
+    }),
     headers: { 'Content-Type': 'application/json' },
   });
 

--- a/src/api/exportApi.js
+++ b/src/api/exportApi.js
@@ -4,8 +4,8 @@ const baseUrl = env.REACT_APP_REST_BACKEND_API;
 
 export async function getSearchResult(body) {
   // TODO: Chunk the export request pages
-  const { pageInfo, ...searchBody } = body || {};
-  const totalItems = pageInfo.total || 10000;
+  const { pageInfo = {}, ...searchBody } = body || {};
+  const totalItems = typeof pageInfo.total === 'number' ? pageInfo.total : 10000;
   const response = await fetch(`${baseUrl}export`, {
     method: 'POST',
     body: JSON.stringify({

--- a/src/api/exportApi.test.js
+++ b/src/api/exportApi.test.js
@@ -1,4 +1,4 @@
-import getSearchResult from './exportApi';
+import getSearchResultUtil from './exportApi';
 import env from '../utils/env';
 
 // Mock the env module
@@ -6,7 +6,7 @@ jest.mock('../utils/env', () => ({
   REACT_APP_REST_BACKEND_API: 'http://api.example.com/',
 }));
 
-describe('getSearchResult tests', () => {
+describe('getSearchResultUtil tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Mock window methods
@@ -38,14 +38,14 @@ describe('getSearchResult tests', () => {
       pageInfo: { total: 100 },
     };
 
-    await getSearchResult(body);
+    await getSearchResultUtil(body);
 
     expect(global.fetch).toHaveBeenCalledWith(
       'http://api.example.com/export',
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-      })
+      }),
     );
   });
 
@@ -62,7 +62,7 @@ describe('getSearchResult tests', () => {
       pageInfo: { page: 2, total: 500 },
     };
 
-    await getSearchResult(body);
+    await getSearchResultUtil(body);
 
     const callArgs = global.fetch.mock.calls[0][1];
     const requestBody = JSON.parse(callArgs.body);
@@ -87,7 +87,7 @@ describe('getSearchResult tests', () => {
       pageInfo: {},
     };
 
-    await getSearchResult(body);
+    await getSearchResultUtil(body);
 
     const callArgs = global.fetch.mock.calls[0][1];
     const requestBody = JSON.parse(callArgs.body);
@@ -102,7 +102,7 @@ describe('getSearchResult tests', () => {
       blob: jest.fn().mockResolvedValueOnce(mockBlob),
     });
 
-    await getSearchResult(null);
+    await getSearchResultUtil(null);
 
     const callArgs = global.fetch.mock.calls[0][1];
     const requestBody = JSON.parse(callArgs.body);
@@ -117,7 +117,7 @@ describe('getSearchResult tests', () => {
       blob: jest.fn().mockResolvedValueOnce(mockBlob),
     });
 
-    await getSearchResult(undefined);
+    await getSearchResultUtil(undefined);
 
     const callArgs = global.fetch.mock.calls[0][1];
     const requestBody = JSON.parse(callArgs.body);
@@ -141,7 +141,7 @@ describe('getSearchResult tests', () => {
       click: clickSpy,
     });
 
-    await getSearchResult({ pageInfo: { total: 100 } });
+    await getSearchResultUtil({ pageInfo: { total: 100 } });
 
     const aElement = createElementSpy.mock.results[0].value;
     expect(aElement.download).toMatch(/^INS datasets download \d{4}-\d{2}-\d{2} \d{2}-\d{2}-\d{2}\.csv$/);
@@ -167,7 +167,7 @@ describe('getSearchResult tests', () => {
     const mockDate = new Date('2026-03-20T14:30:45');
     jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
 
-    await getSearchResult({ pageInfo: { total: 100 } });
+    await getSearchResultUtil({ pageInfo: { total: 100 } });
 
     const aElement = createElementSpy.mock.results[0].value;
     expect(aElement.download).toBe('INS datasets download 2026-03-20 14-30-45.csv');
@@ -189,7 +189,7 @@ describe('getSearchResult tests', () => {
       click: clickSpy,
     });
 
-    await getSearchResult({ pageInfo: { total: 100 } });
+    await getSearchResultUtil({ pageInfo: { total: 100 } });
 
     expect(clickSpy).toHaveBeenCalled();
   });
@@ -209,7 +209,7 @@ describe('getSearchResult tests', () => {
       click: jest.fn(),
     });
 
-    await getSearchResult({ pageInfo: { total: 100 } });
+    await getSearchResultUtil({ pageInfo: { total: 100 } });
 
     expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
@@ -224,8 +224,8 @@ describe('getSearchResult tests', () => {
 
     const body = { search_text: 'test', pageInfo: { total: 100 } };
 
-    await expect(getSearchResult(body)).rejects.toThrow(
-      'Export request failed with status 400 Bad Request: Invalid search criteria'
+    await expect(getSearchResultUtil(body)).rejects.toThrow(
+      'Export request failed with status 400 Bad Request: Invalid search criteria',
     );
   });
 
@@ -239,8 +239,8 @@ describe('getSearchResult tests', () => {
 
     const body = { search_text: 'test', pageInfo: { total: 100 } };
 
-    await expect(getSearchResult(body)).rejects.toThrow(
-      'Export request failed with status 500 Internal Server Error'
+    await expect(getSearchResultUtil(body)).rejects.toThrow(
+      'Export request failed with status 500 Internal Server Error',
     );
   });
 
@@ -254,8 +254,8 @@ describe('getSearchResult tests', () => {
 
     const body = { search_text: 'test', pageInfo: { total: 100 } };
 
-    await expect(getSearchResult(body)).rejects.toThrow(
-      'Export request failed with status 403: Forbidden'
+    await expect(getSearchResultUtil(body)).rejects.toThrow(
+      'Export request failed with status 403: Forbidden',
     );
   });
 
@@ -273,7 +273,7 @@ describe('getSearchResult tests', () => {
       pageInfo: { page: 5, pageSize: 20, total: 1000 },
     };
 
-    await getSearchResult(body);
+    await getSearchResultUtil(body);
 
     const callArgs = global.fetch.mock.calls[0][1];
     const requestBody = JSON.parse(callArgs.body);
@@ -290,7 +290,7 @@ describe('getSearchResult tests', () => {
 
     const body = { search_text: 'test', pageInfo: { total: 100 } };
 
-    await expect(getSearchResult(body)).rejects.toThrow('Network request failed');
+    await expect(getSearchResultUtil(body)).rejects.toThrow('Network request failed');
   });
 
   it('should set blob as href on the anchor element', async () => {
@@ -307,7 +307,7 @@ describe('getSearchResult tests', () => {
       click: jest.fn(),
     });
 
-    await getSearchResult({ pageInfo: { total: 100 } });
+    await getSearchResultUtil({ pageInfo: { total: 100 } });
 
     const aElement = createElementSpy.mock.results[0].value;
     expect(aElement.href).toBe('blob:mock-url');
@@ -322,7 +322,7 @@ describe('getSearchResult tests', () => {
 
     const body = { pageInfo: { total: 0 } };
 
-    await getSearchResult(body);
+    await getSearchResultUtil(body);
 
     const callArgs = global.fetch.mock.calls[0][1];
     const requestBody = JSON.parse(callArgs.body);
@@ -339,7 +339,7 @@ describe('getSearchResult tests', () => {
 
     const body = { pageInfo: { total: 1000000 } };
 
-    await getSearchResult(body);
+    await getSearchResultUtil(body);
 
     const callArgs = global.fetch.mock.calls[0][1];
     const requestBody = JSON.parse(callArgs.body);

--- a/src/api/exportApi.test.js
+++ b/src/api/exportApi.test.js
@@ -1,0 +1,349 @@
+import getSearchResult from './exportApi';
+import env from '../utils/env';
+
+// Mock the env module
+jest.mock('../utils/env', () => ({
+  REACT_APP_REST_BACKEND_API: 'http://api.example.com/',
+}));
+
+describe('getSearchResult tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock window methods
+    Object.defineProperty(window, 'URL', {
+      value: {
+        createObjectURL: jest.fn(() => 'blob:mock-url'),
+        revokeObjectURL: jest.fn(),
+      },
+      writable: true,
+    });
+    // Mock document.createElement
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should fetch from the correct API endpoint', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const body = {
+      search_text: 'cancer',
+      filters: { disease: ['Lung Cancer'] },
+      pageInfo: { total: 100 },
+    };
+
+    await getSearchResult(body);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://api.example.com/export',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+
+  it('should send correct request body with pageInfo.total', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const body = {
+      search_text: 'cancer',
+      filters: { disease: ['Lung Cancer'] },
+      pageInfo: { page: 2, total: 500 },
+    };
+
+    await getSearchResult(body);
+
+    const callArgs = global.fetch.mock.calls[0][1];
+    const requestBody = JSON.parse(callArgs.body);
+
+    expect(requestBody).toEqual({
+      search_text: 'cancer',
+      filters: { disease: ['Lung Cancer'] },
+      pageInfo: { page: 1, pageSize: 500 },
+    });
+  });
+
+  it('should use default pageSize of 10000 when pageInfo.total is undefined', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const body = {
+      search_text: 'cancer',
+      filters: { disease: ['Lung Cancer'] },
+      pageInfo: {},
+    };
+
+    await getSearchResult(body);
+
+    const callArgs = global.fetch.mock.calls[0][1];
+    const requestBody = JSON.parse(callArgs.body);
+
+    expect(requestBody.pageInfo.pageSize).toBe(10000);
+  });
+
+  it('should handle null body gracefully', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    await getSearchResult(null);
+
+    const callArgs = global.fetch.mock.calls[0][1];
+    const requestBody = JSON.parse(callArgs.body);
+
+    expect(requestBody.pageInfo.pageSize).toBe(10000);
+  });
+
+  it('should handle undefined body gracefully', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    await getSearchResult(undefined);
+
+    const callArgs = global.fetch.mock.calls[0][1];
+    const requestBody = JSON.parse(callArgs.body);
+
+    expect(requestBody.pageInfo.pageSize).toBe(10000);
+  });
+
+  it('should create a download link with the correct filename format', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+    const clickSpy = jest.fn();
+
+    createElementSpy.mockReturnValueOnce({
+      href: '',
+      download: '',
+      click: clickSpy,
+    });
+
+    await getSearchResult({ pageInfo: { total: 100 } });
+
+    const aElement = createElementSpy.mock.results[0].value;
+    expect(aElement.download).toMatch(/^INS datasets download \d{4}-\d{2}-\d{2} \d{2}-\d{2}-\d{2}\.csv$/);
+  });
+
+  it('should set the download filename with proper date and time format', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+    const clickSpy = jest.fn();
+
+    createElementSpy.mockReturnValueOnce({
+      href: '',
+      download: '',
+      click: clickSpy,
+    });
+
+    // Mock Date to control the timestamp
+    const mockDate = new Date('2026-03-20T14:30:45');
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    await getSearchResult({ pageInfo: { total: 100 } });
+
+    const aElement = createElementSpy.mock.results[0].value;
+    expect(aElement.download).toBe('INS datasets download 2026-03-20 14-30-45.csv');
+  });
+
+  it('should trigger the click event to download the file', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+    const clickSpy = jest.fn();
+
+    createElementSpy.mockReturnValueOnce({
+      href: '',
+      download: '',
+      click: clickSpy,
+    });
+
+    await getSearchResult({ pageInfo: { total: 100 } });
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('should revoke the object URL after download', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+
+    createElementSpy.mockReturnValueOnce({
+      href: '',
+      download: '',
+      click: jest.fn(),
+    });
+
+    await getSearchResult({ pageInfo: { total: 100 } });
+
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('should throw error with message when response is not ok', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: jest.fn().mockResolvedValueOnce('Invalid search criteria'),
+    });
+
+    const body = { search_text: 'test', pageInfo: { total: 100 } };
+
+    await expect(getSearchResult(body)).rejects.toThrow(
+      'Export request failed with status 400 Bad Request: Invalid search criteria'
+    );
+  });
+
+  it('should throw error with generic message when response error has no text', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: jest.fn().mockResolvedValueOnce(''),
+    });
+
+    const body = { search_text: 'test', pageInfo: { total: 100 } };
+
+    await expect(getSearchResult(body)).rejects.toThrow(
+      'Export request failed with status 500 Internal Server Error'
+    );
+  });
+
+  it('should throw error when status is provided but statusText is empty', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: '',
+      text: jest.fn().mockResolvedValueOnce('Forbidden'),
+    });
+
+    const body = { search_text: 'test', pageInfo: { total: 100 } };
+
+    await expect(getSearchResult(body)).rejects.toThrow(
+      'Export request failed with status 403: Forbidden'
+    );
+  });
+
+  it('should preserve search body fields while modifying pageInfo', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const body = {
+      search_text: 'cancer',
+      filters: { disease: ['Lung'], source: ['dbGaP'] },
+      sort: { field: 'name', order: 'asc' },
+      pageInfo: { page: 5, pageSize: 20, total: 1000 },
+    };
+
+    await getSearchResult(body);
+
+    const callArgs = global.fetch.mock.calls[0][1];
+    const requestBody = JSON.parse(callArgs.body);
+
+    expect(requestBody.search_text).toBe('cancer');
+    expect(requestBody.filters).toEqual({ disease: ['Lung'], source: ['dbGaP'] });
+    expect(requestBody.sort).toEqual({ field: 'name', order: 'asc' });
+    expect(requestBody.pageInfo).toEqual({ page: 1, pageSize: 1000 });
+  });
+
+  it('should handle fetch network errors', async () => {
+    const networkError = new Error('Network request failed');
+    global.fetch.mockRejectedValueOnce(networkError);
+
+    const body = { search_text: 'test', pageInfo: { total: 100 } };
+
+    await expect(getSearchResult(body)).rejects.toThrow('Network request failed');
+  });
+
+  it('should set blob as href on the anchor element', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+    createElementSpy.mockReturnValueOnce({
+      href: '',
+      download: '',
+      click: jest.fn(),
+    });
+
+    await getSearchResult({ pageInfo: { total: 100 } });
+
+    const aElement = createElementSpy.mock.results[0].value;
+    expect(aElement.href).toBe('blob:mock-url');
+  });
+
+  it('should handle zero as a valid pageInfo.total value', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const body = { pageInfo: { total: 0 } };
+
+    await getSearchResult(body);
+
+    const callArgs = global.fetch.mock.calls[0][1];
+    const requestBody = JSON.parse(callArgs.body);
+
+    expect(requestBody.pageInfo.pageSize).toBe(0);
+  });
+
+  it('should handle large pageInfo.total values', async () => {
+    const mockBlob = new Blob(['test data'], { type: 'text/csv' });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const body = { pageInfo: { total: 1000000 } };
+
+    await getSearchResult(body);
+
+    const callArgs = global.fetch.mock.calls[0][1];
+    const requestBody = JSON.parse(callArgs.body);
+
+    expect(requestBody.pageInfo.pageSize).toBe(1000000);
+  });
+});


### PR DESCRIPTION
### Overview

This PR changes the export button to explicitly request all data, and also adds unit tests to the exportAPI functionality.

### Change Details (Specifics)

N/A

### Related Ticket(s)

INS-1573